### PR TITLE
Render template to callback instead of client

### DIFF
--- a/lib/locomotive/controller.js
+++ b/lib/locomotive/controller.js
@@ -92,7 +92,7 @@ Controller.prototype.render = function(template, options) {
   });
   
   var view = tmpl + '.' + fmt + '.' + eng;
-  this.__res.render(view, options);
+  this.__res.render(view, options, options.callback);
 }
 
 /**


### PR DESCRIPTION
It would be great to be able to render (like in express) a template to a callback to be able to then use the rendered content in an email or such like.

Something like:

``` javascript
self.render('email/confirm', {
  callback: function (err, html) {
    console.log(err, html);
  },
  layout: 'email'
})
```
