### PR TITLE
Using modular controllers for resource and resources

### DIFF
--- a/lib/locomotive/router.js
+++ b/lib/locomotive/router.js
@@ -208,7 +208,13 @@ Router.prototype.match = function(pattern, shorthand, options) {
  * @param {String} name
  * @api public
  */
-Router.prototype.resource = function(name, fn) {
+Router.prototype.resource = function(name, options, fn) {
+  if (typeof options === 'function') {
+    fn = options;
+    options = {};
+  }
+  options = options || {}
+  
   var ns = this._ns[this._ns.length - 1]
     , path = ns.qpath(name)
     , controller = ns.qcontroller(name)
@@ -225,7 +231,7 @@ Router.prototype.resource = function(name, fn) {
   this._route('put' , path              , controller, 'update' );
   this._route('del' , path              , controller, 'destroy');
   
-  this.namespace(name, { module: null, helper: name }, function() {
+  this.namespace(name, { module: options.namespace ? name : null, helper: name }, function() {
     fn && fn.call(this);
   });
 }
@@ -274,7 +280,13 @@ Router.prototype.resource = function(name, fn) {
  * @param {String} name
  * @api public
  */
-Router.prototype.resources = function(name, fn) {
+Router.prototype.resources = function(name, options, fn) {
+  if (typeof options === 'function') {
+    fn = options;
+    options = {};
+  }
+  options = options || {}
+  
   var ns = this._ns[this._ns.length - 1]
     , singular = lingo.en.singularize(name)
     , path = ns.qpath(name)
@@ -297,7 +309,7 @@ Router.prototype.resources = function(name, fn) {
   // TODO: I think placeholder should be underscored.  Test for this.
   // TODO: Implement support for dasherized names.
   placeholder = ':' + utils.helperize(singular) + '_id';
-  this.namespace(name + '/' + placeholder, { module: null, helper: singular }, function() {
+  this.namespace(name + '/' + placeholder, { module: options.namespace ? name : null, helper: singular }, function() {
     fn && fn.call(this);
   });
 }


### PR DESCRIPTION
Would it not make sense to use modular controllers for both resource and resources routes too?

This line sets module = null which means any sub resource or resources are pointers to regular controllers.

https://github.com/jaredhanson/locomotive/blob/master/lib/locomotive/router.js#L228

I propose that we should force, or allow people to use the namespace structure for nested resource, making it easier to segment the platform.

e.g.

this.resource('account', function () {
  this.resource('profile');
})

Would route:

/account -> AccountController
/account/Profile => Account::ProfileController

Hope this makes sense!
