### PR TITLE
RegExp matching within routes

### DIFF
--- a/lib/locomotive/namespace.js
+++ b/lib/locomotive/namespace.js
@@ -30,12 +30,23 @@ function Namespace(path, options, parent) {
 Namespace.prototype.qpath = function(path) {
   var qual = path;
   var ns = this;
+  var nsPath = '';
   while (ns) {
-    qual = (ns.path.length) ? ((qual[0] === '/') ? (ns.path + qual) : (ns.path + '/' + qual)) : (qual);
+    nsPath = (ns.path.length) ? ((nsPath[0] === '/') ? (ns.path + nsPath) : (ns.path + '/' + nsPath)) : (nsPath);
     ns = ns.parent;
   }
-  qual = (qual[0] === '/') ? (qual) : ('/' + qual);
-  qual = (qual.length > 1 && qual[qual.length - 1] === '/') ? (qual.slice(0, qual.length - 1)) : (qual);
+  nsPath = (nsPath[0] === '/') ? (nsPath) : ('/' + nsPath);
+
+  if (qual instanceof RegExp) {
+    qual = new RegExp(
+      '^' +
+      nsPath.replace('/', '\\/') +
+      qual.toString().match(/[/\\^]*(.*)\/[ig]{0,1}$/)[1]
+    )
+  } else {
+    qual = nsPath + qual;
+    qual = (qual.length > 1 && qual[qual.length - 1] === '/') ? (qual.slice(0, qual.length - 1)) : (qual);
+  }
   return qual;
 }
 


### PR DESCRIPTION
Would be awesome to be able to use regexp matching within routes, this is supported in express, just the munging of paths within namespace.js converts the regexp to a string and modifies it

```
this.match(/^\/\/?(?!anythingbutthis))/i, function (req, res, next) {})
```
