### PR TITLE
Added support for specifying multiple actions per filter

### DIFF
--- a/lib/locomotive/controller.js
+++ b/lib/locomotive/controller.js
@@ -309,6 +309,9 @@ Controller.prototype.before = function(action, fn) {
     }
   }
   
+  // if '*', expand into array of methods
+  if (action === '*') action = this.getActions();
+
   // check if action contains a list of actions
   if (Array.isArray(action)) {
       // add hooks to applicable actions
@@ -357,6 +360,9 @@ Controller.prototype.after = function(action, fn) {
       fn.call(this, done);
     }
   }
+
+  // if '*', expand into array of methods
+  if (action === '*') action = this.getActions();
   
   // check if action contains a list of actions
   if (Array.isArray(action)) {
@@ -368,6 +374,19 @@ Controller.prototype.after = function(action, fn) {
       // Install middleware for action using post() function provided by hooks.
       this.post(action, filter);
   }
+}
+
+/**
+ * Get a list of actions implemented by the current controller.
+ */
+Controller.prototype.getActions = function() {
+    var actions = new Array();
+    for ( key in this ) {
+        if (this.hasOwnProperty(key) && (typeof(this[key] == 'function'))) {
+            actions.push(key);
+        }
+    }
+    return actions;
 }
 
 // Add hooks to support pre and post filters.


### PR DESCRIPTION
With the change, filters can be added to multiple actions by passing in an array. Like:

``` javascript
PhotosController.before( ['create', 'edit'], redirectIfNotSignedIn() );
```

To add a filter for all actions, use '*' for action:

``` javascript
PhotosController.before('*', redirectIfNotSignedIn());
```

Was torned between that and a beforeAll method, but figured I would do asterisk for now.
