### PR TITLE
Allow usage of app.locals({ ... }) as this.locals({ ... }) within environment

### DIFF
--- a/lib/locomotive/index.js
+++ b/lib/locomotive/index.js
@@ -189,7 +189,7 @@ Locomotive.prototype.boot = function(dir, env, options, callback) {
   // Forward function calls from Locomotive to Express.  This allows Locomotive
   // to be used interchangably with Express.
   utils.forward(this, app, [ 'get', 'set', 'enabled', 'disabled', 'enable', 'disable',
-                             'use', 'engine' ]);
+                             'use', 'engine', 'locals' ]);
   this.router = app.router;
   
   // Set the environment.  This syncs Express with the environment supplied to


### PR DESCRIPTION
Express 3 allows setting global locals (including _layoutFile which allows use of Express 2 layouts ;) )
