### PR TITLE
Added forwarder for app.configure()

### DIFF
--- a/lib/locomotive/index.js
+++ b/lib/locomotive/index.js
@@ -239,7 +239,7 @@ Locomotive.prototype.boot = function(dir, env, options, callback) {
   
   // Forward function calls from Locomotive to Express.  This allows Locomotive
   // to be used interchangably with Express.
-  utils.forward(this, app, [ 'get', 'set', 'enabled', 'disabled', 'enable', 'disable',
+  utils.forward(this, app, [ 'configure', 'get', 'set', 'enabled', 'disabled', 'enable', 'disable',
                              'use', 'engine', 'locals' ]);
   this.router = app.router;
   this.mime = express.mime;


### PR DESCRIPTION
This is a super-tiny change but for some reason it wasn't forwarded like the other express functions (get, set, enable, disable, etc) Any reason for that?

The function doesn't do much (it's really just an if statement) but i've found it looks quite tidy, and it's there already so why not. 

I prefer to set any environment differences in the same file as other related functions, and with loco 0.3.x I now have my initializers all nicely organised and barely anything in the environment files.. No more looking in 4 different places to change a setting and goodbye code smell! 

Great work Jared! :D

Linkage: http://expressjs.com/api.html#app.configure
