### PR TITLE
urlFor defaults to request protocol not 'http'

### DIFF
--- a/lib/locomotive/helpers/dynamic/url.js
+++ b/lib/locomotive/helpers/dynamic/url.js
@@ -69,7 +69,7 @@ function urlFor(req, res) {
     options.action = utils.actionize(options.action) || req._locomotive.action;
     
     if (req.headers && req.headers['host']) {
-      options.protocol = options.protocol || 'http';
+      options.protocol = options.protocol || req.protocol;
       options.host = options.host || req.headers['host'];
     }
     


### PR DESCRIPTION
When running Locomotive as https or behind a x-forward style proxy ensure urls are generated with the current protocol rather than defaulting to http.
