### PR TITLE
.before('*' and .after('*' ignore functions beginning with _

### DIFF
--- a/lib/locomotive/controller.js
+++ b/lib/locomotive/controller.js
@@ -369,7 +369,7 @@ Controller.prototype._invoke = function(action) {
 Controller.prototype._actions = function() {
   var actions = new Array();
   for (var key in this) {
-    if (this.hasOwnProperty(key) && (typeof this[key] == 'function')) {
+    if (this.hasOwnProperty(key) && (typeof this[key] == 'function') && key.charAt(0) !== '_') {
       actions.push(key);
     }
   }


### PR DESCRIPTION
Fringe case, but I store the model associated with a controller as ._model, the model is a function, which before and after attempt to wrap when using '*'. This patch ignores all functions beginning with '_' to better allow custom attributes to be stored against controllers.
