### PR TITLE
Improved absolute view path lookups

### DIFF
--- a/lib/locomotive/controller.js
+++ b/lib/locomotive/controller.js
@@ -97,7 +97,7 @@ Controller.prototype.render = function(template, options, fn) {
   var tmpl = template || utils.underscore(this.__action)
     , fmt = utils.extensionizeType(options.format || 'html');
   
-  tmpl = (tmpl.indexOf('/') === -1) ? path.join(this.__viewDir, tmpl) : tmpl;
+  tmpl = tmpl.charAt(0) === '/' ? tmpl.slice(1) : path.join(this.__viewDir, tmpl);
   
   // Filter function to capture the controller's local properties, which will
   // be made available to the view.  Any private property (defined as a property


### PR DESCRIPTION
View paths now resolved as follows:
'show' == __viewDir + 'show'
'../rar/show == __viewDir + '../rar/show'
'/show' == 'show'

Previously any paths starting '/' would be absolute to fs root.
