### PR TITLE
Explicit binding of functions/methods passed to template engine

### DIFF
--- a/lib/locomotive/controller.js
+++ b/lib/locomotive/controller.js
@@ -456,7 +456,7 @@ Controller.prototype._invoke = function(action) {
         self[action]();
         return;
       } catch (e) {
-        return self.error(err);
+        return self.error(e);
       }
     }
     


### PR DESCRIPTION
I ran into an issue trying to get the [Swig template engine](http://paularmstrong.github.com/swig/) to work with Locomotive: using any of the `*Path()` functions from within templates failed with a type error: `TypeError: Object #<Object> has no method 'urlFor'`.

Not quite sure who's at fault, but the reason turns out to be that the `*Path()` functions weren't bound to the current controller instance (but to the global app object, I think), and thus were running in the wrong context.

This patch explicitly binds all functions passed to the template engine to the current controller, which has solved my problems.
