### PR TITLE
Allow selecting which actions a filter applies to using 'only' and 'except'

### DIFF
--- a/lib/locomotive/controller.js
+++ b/lib/locomotive/controller.js
@@ -573,6 +573,15 @@ Controller.prototype.before = function(action, fn) {
   // If '*', expand into array of all actions.
   if (action === '*') action = this._actions();
 
+  if (action.only) {
+    action = Array.isArray(action.only) ? action.only : [ action.only ];
+  } else if (action.except) {
+    var except = Array.isArray(action.except) ? action.except : [ action.except ];
+    action = this._actions().filter(function(a) {
+      return except.indexOf(a) == -1;
+    });
+  }
+
   if (Array.isArray(action)) {
     // If multiple actions specified, add the filter to each of them.
     for (var i = 0, len = action.length; i < len; i++) {
@@ -604,6 +613,15 @@ Controller.prototype.before = function(action, fn) {
 Controller.prototype.after = function(action, fn) {
   // If '*', expand into array of all actions.
   if (action === '*') action = this._actions();
+
+  if (action.only) {
+    action = Array.isArray(action.only) ? action.only : [ action.only ];
+  } else if (action.except) {
+    var except = Array.isArray(action.except) ? action.except : [ action.except ];
+    action = this._actions().filter(function(a) {
+      return except.indexOf(a) == -1;
+    });
+  }  
   
   // check if action contains a list of actions
   if (Array.isArray(action)) {

--- a/test/controller-test.js
+++ b/test/controller-test.js
@@ -1715,6 +1715,146 @@ vows.describe('Controller').addBatch({
       },
     },
   },
+
+  'controller instance with before filter on only foo action': {
+    topic: function() {
+      var TestController = new Controller();
+      TestController._load(new MockLocomotive(), 'TestController');
+      
+      TestController.foo = function() {
+        this.song = 'the-end';
+        this.render();
+      }
+      TestController.bar = function() {
+        this.song = 'break-on-through';
+        this.render();
+      }
+      TestController.before({ only: ['foo'] }, function(next) {
+        this.band = 'the-doors';
+        next();
+      });
+      
+      return TestController;
+    },
+    
+    'invoking first action with before filter': {
+      topic: function(TestController) {
+        var controller = Object.create(TestController);
+        var self = this;
+        var req, res;
+        
+        req = new MockRequest();
+        res = new MockResponse(function() {
+          self.callback(null, controller, req, res);
+        });
+        controller._init(req, res);
+        controller._invoke('foo');
+      },
+      
+      'should assign controller properties as response locals': function(err, c, req, res) {
+        assert.lengthOf(Object.keys(res.locals), 2);
+        assert.equal(res.locals.band, 'the-doors');
+        assert.equal(res.locals.song, 'the-end');
+      },
+      'should render view': function(err, c, req, res) {
+        assert.equal(res._view, 'test/foo.html.ejs');
+      },
+    },
+    
+    'invoking second action with before filter': {
+      topic: function(TestController) {
+        var controller = Object.create(TestController);
+        var self = this;
+        var req, res;
+        
+        req = new MockRequest();
+        res = new MockResponse(function() {
+          self.callback(null, controller, req, res);
+        });
+        controller._init(req, res);
+        controller._invoke('bar');
+      },
+      
+      'should assign controller properties as response locals': function(err, c, req, res) {
+        assert.lengthOf(Object.keys(res.locals), 1);
+        assert.equal(res.locals.band, undefined);
+        assert.equal(res.locals.song, 'break-on-through');
+      },
+      'should render view': function(err, c, req, res) {
+        assert.equal(res._view, 'test/bar.html.ejs');
+      },
+    },
+  },
+
+  'controller instance with before filter on all actions except bar': {
+    topic: function() {
+      var TestController = new Controller();
+      TestController._load(new MockLocomotive(), 'TestController');
+      
+      TestController.foo = function() {
+        this.song = 'the-end';
+        this.render();
+      }
+      TestController.bar = function() {
+        this.song = 'break-on-through';
+        this.render();
+      }
+      TestController.before({ except: ['bar'] }, function(next) {
+        this.band = 'the-doors';
+        next();
+      });
+      
+      return TestController;
+    },
+    
+    'invoking first action with before filter': {
+      topic: function(TestController) {
+        var controller = Object.create(TestController);
+        var self = this;
+        var req, res;
+        
+        req = new MockRequest();
+        res = new MockResponse(function() {
+          self.callback(null, controller, req, res);
+        });
+        controller._init(req, res);
+        controller._invoke('foo');
+      },
+      
+      'should assign controller properties as response locals': function(err, c, req, res) {
+        assert.lengthOf(Object.keys(res.locals), 2);
+        assert.equal(res.locals.band, 'the-doors');
+        assert.equal(res.locals.song, 'the-end');
+      },
+      'should render view': function(err, c, req, res) {
+        assert.equal(res._view, 'test/foo.html.ejs');
+      },
+    },
+    
+    'invoking second action without before filter': {
+      topic: function(TestController) {
+        var controller = Object.create(TestController);
+        var self = this;
+        var req, res;
+        
+        req = new MockRequest();
+        res = new MockResponse(function() {
+          self.callback(null, controller, req, res);
+        });
+        controller._init(req, res);
+        controller._invoke('bar');
+      },
+      
+      'should assign controller properties as response locals': function(err, c, req, res) {
+        assert.lengthOf(Object.keys(res.locals), 1);
+        assert.equal(res.locals.band, undefined);
+        assert.equal(res.locals.song, 'break-on-through');
+      },
+      'should render view': function(err, c, req, res) {
+        assert.equal(res._view, 'test/bar.html.ejs');
+      },
+    },
+  },
   
   'controller instance with before filter on all actions': {
     topic: function() {
@@ -2055,6 +2195,162 @@ vows.describe('Controller').addBatch({
       },
       'should assign controller properties in after filters': function(err, c, req, res) {
         assert.equal(c.band, 'the-doors');
+      },
+      'should render view': function(err, c, req, res) {
+        assert.equal(res._view, 'test/bar.html.ejs');
+      },
+    },
+  },
+  
+  'controller instance with after filter on only foo action': {
+    topic: function() {
+      var TestController = new Controller();
+      TestController._load(new MockLocomotive(), 'TestController');
+      
+      TestController.foo = function() {
+        this.song = 'the-end';
+        this.render();
+      }
+      TestController.bar = function() {
+        this.song = 'break-on-through';
+        this.render();
+      }
+      TestController.after({ only: ['foo'] }, function(next) {
+        this.band = 'the-doors';
+        this.finished();
+        next();
+      });
+      
+      return TestController;
+    },
+    
+    'invoking first action with after filter': {
+      topic: function(TestController) {
+        var controller = Object.create(TestController);
+        var self = this;
+        var req, res;
+        
+        req = new MockRequest();
+        res = new MockResponse();
+        controller.finished = function() {
+          self.callback(null, controller, req, res);
+        }
+        
+        controller._init(req, res);
+        controller._invoke('foo');
+      },
+      
+      'should assign controller properties as response locals': function(err, c, req, res) {
+        assert.lengthOf(Object.keys(res.locals), 1);
+        assert.equal(res.locals.song, 'the-end');
+      },
+      'should assign controller properties in after filters': function(err, c, req, res) {
+        assert.equal(c.band, 'the-doors');
+      },
+      'should render view': function(err, c, req, res) {
+        assert.equal(res._view, 'test/foo.html.ejs');
+      },
+    },
+    
+    'invoking second action without after filter': {
+      topic: function(TestController) {
+        var controller = Object.create(TestController);
+        var self = this;
+        var req, res;
+        
+        req = new MockRequest();
+        res = new MockResponse(function() {
+          self.callback(null, controller, req, res);
+        });
+        
+        controller._init(req, res);
+        controller._invoke('bar');
+      },
+      
+      'should assign controller properties as response locals': function(err, c, req, res) {
+        assert.lengthOf(Object.keys(res.locals), 1);
+        assert.equal(res.locals.song, 'break-on-through');
+      },
+      'should not assign any controller properties in after filters': function(err, c, req, res) {
+        assert.equal(c.band, undefined);
+      },
+      'should render view': function(err, c, req, res) {
+        assert.equal(res._view, 'test/bar.html.ejs');
+      },
+    },
+  },
+  
+  'controller instance with after filter on all actions except bar': {
+    topic: function() {
+      var TestController = new Controller();
+      TestController._load(new MockLocomotive(), 'TestController');
+      
+      TestController.foo = function() {
+        this.song = 'the-end';
+        this.render();
+      }
+      TestController.bar = function() {
+        this.song = 'break-on-through';
+        this.render();
+      }
+      TestController.after({ except: ['bar'] }, function(next) {
+        this.band = 'the-doors';
+        this.finished();
+        next();
+      });
+      
+      return TestController;
+    },
+    
+    'invoking first action with after filter': {
+      topic: function(TestController) {
+        var controller = Object.create(TestController);
+        var self = this;
+        var req, res;
+        
+        req = new MockRequest();
+        res = new MockResponse();
+        controller.finished = function() {
+          self.callback(null, controller, req, res);
+        }
+        
+        controller._init(req, res);
+        controller._invoke('foo');
+      },
+      
+      'should assign controller properties as response locals': function(err, c, req, res) {
+        assert.lengthOf(Object.keys(res.locals), 1);
+        assert.equal(res.locals.song, 'the-end');
+      },
+      'should assign controller properties in after filters': function(err, c, req, res) {
+        assert.equal(c.band, 'the-doors');
+      },
+      'should render view': function(err, c, req, res) {
+        assert.equal(res._view, 'test/foo.html.ejs');
+      },
+    },
+    
+    'invoking second action without after filter': {
+      topic: function(TestController) {
+        var controller = Object.create(TestController);
+        var self = this;
+        var req, res;
+        
+        req = new MockRequest();
+        res = new MockResponse(function() {
+          self.callback(null, controller, req, res);
+        });
+        
+        controller._init(req, res);
+        controller._invoke('bar');
+      },
+      
+      'should assign controller properties as response locals': function(err, c, req, res) {
+        assert.lengthOf(Object.keys(res.locals), 1);
+        assert.equal(res.locals.song, 'break-on-through');
+      },
+      'should not assign any controller properties in after filters': function(err, c, req, res) {
+        assert.equal(c.band, undefined);
       },
       'should render view': function(err, c, req, res) {
         assert.equal(res._view, 'test/bar.html.ejs');


### PR DESCRIPTION
This is a feature request.

I find that it would be very useful if we could specify which controller actions we want to apply a filter to, in a similar manner how we can define resourceful routes.

I imagine something like this:

``` javascript
UsersController.before({ only: ['show','create']}, function(next) {
  next();
});

UsersController.before({ except: ['destroy']}, function(next) {
  next();
});
```

This becomes very useful when you need to apply a filter to more than one, but not all your actions. Keeps things DRY.

EDIT: Looking at the source code I realized that it's already possible to apply a filter to multiple actions when passing an array of actions instead a single action name or wilcard. Still, it would be nice if we could apply filters to all actions, except a few.
