### PR TITLE
Server.js generation to make it not required to run the server with lcm.

### DIFF
--- a/lib/locomotive/cli/create.js
+++ b/lib/locomotive/cli/create.js
@@ -194,11 +194,29 @@ var packageJSON = [
   , '    "express": "3.x.x",'
   , '    "connect-powered-by": "0.1.x",'
   , '    "ejs": "0.8.x"'
-  , '  }'
+  , '  },'
+  , '  "main": "./server.js"'
   , '}'
   , ''
 ].join(eol);
 
+var serverJS = [
+    'var locomotive = require(\'locomotive\'),'
+  , '                 env = process.env.NODE_ENV || \'development\','
+  , '                 port =  process.argv[2] || process.env.PORT || 3000,'
+  , '                 address = \'0.0.0.0\';'
+  , ''
+  , 'console.log(process.argv);'
+  , ''
+  , 'locomotive.boot(__dirname, env, function(err, server) {'
+  , '    if (err) { throw err; }'
+  , '        server.listen(port, address, function() {'
+  , '        var addr = this.address();'
+  , '        console.log(\'listening on %s:%d\', addr.address, addr.port);'
+  , '    });'
+  , '});'
+  , ''
+].join(eol);
 
 /**
  * Create application at the given directory `path`.
@@ -246,6 +264,7 @@ function createApplicationAt(path) {
     });
     
     write(path + '/package.json', packageJSON);
+    write(path + '/server.js', serverJS);
   });
 }
 


### PR DESCRIPTION
...the package.json main. Fix for Issue #75.

On a side note if not running through lcm and just using node in the directory it will run with defaults, you can also run from nodemon directly now. nodemon project 1337 would load the project in nodemon using port 1337.
