### PR TITLE
Store HTTP server in `locomotive` object.

### DIFF
--- a/lib/locomotive/index.js
+++ b/lib/locomotive/index.js
@@ -12,7 +12,8 @@ var express = require('express')
   , Router = require('./router')
   , Controller = require('./controller')
   , invoke = require('./middleware/invoke')
-  , debug = require('debug')('locomotive');
+  , debug = require('debug')('locomotive')
+  , http = require('http');;
 
 
 /**
@@ -261,6 +262,7 @@ Locomotive.prototype.boot = function(dir, env, options, callback) {
   
   var self = this
     , app = express()
+    , server = http.createServer(app)
     , exts = [ 'js' ];
     
   if (options.coffee || options.coffeeScript) {
@@ -278,6 +280,7 @@ Locomotive.prototype.boot = function(dir, env, options, callback) {
   this.express = app;
   this.router = app.router;
   this.mime = express.mime;
+  this.server = server;
   
   this.helpers(require('./helpers'));
   this.dynamicHelpers(require('./helpers/dynamic'));
@@ -396,7 +399,7 @@ Locomotive.prototype.boot = function(dir, env, options, callback) {
     ],
     function(err, results) {
       if (err) { return callback(err); }
-      callback(null, app);
+      callback(null, server);
     }
   );
 }


### PR DESCRIPTION
This allows using the server object later on, such as in an initializer for the purpose of creating WebSocket servers.
