### PR TITLE
[Fix] Locomotive implementation of Express.app.locals

### DIFF
--- a/lib/locomotive/index.js
+++ b/lib/locomotive/index.js
@@ -35,7 +35,7 @@ function Locomotive() {
 };
 
 /**
- * Register `controller` with given `name`, or return `name`'s controller. 
+ * Register `controller` with given `name`, or return `name`'s controller.
  *
  * @param {String} name
  * @param {Controller} controller
@@ -129,7 +129,7 @@ Locomotive.prototype.helpers = function(name, fn) {
     helpers = {};
     helpers[name] = fn;
   }
-  
+
   for (var key in helpers) {
     if (key === 'dynamic') {
       this.dynamicHelpers(helpers[key]);
@@ -160,7 +160,7 @@ Locomotive.prototype.dynamicHelpers = function(name, fn) {
     helpers = {};
     helpers[name] = fn;
   }
-  
+
   for (var key in helpers) {
     this._dynamicHelpers[key] = helpers[key];
   }
@@ -213,7 +213,7 @@ Locomotive.prototype.invoke = function(options) {
 
 /**
  * Returns a string indicating the type of record of `obj`.
- * 
+ *
  * @param {Object} obj
  * @return {String}
  * @api protected
@@ -257,48 +257,50 @@ Locomotive.prototype.boot = function(dir, env, options, callback) {
     options = {};
   }
   options = options || {};
-  
+
   if (!existsSync(dir)) { return callback(new Error('Application does not exist: ' + dir)); }
   options.controllersDir = options.controllersDir || path.resolve(dir, './app/controllers');
   options.environmentsDir = options.environmentsDir || path.resolve(dir, './config/environments');
   options.initializersDir = options.initializersDir || path.resolve(dir, './config/initializers');
   options.routesFile = options.routesFile || path.resolve(dir, './config/routes');
-  
+
   var self = this
     , app = express()
     , exts = [ 'js' ];
-    
+
   if (options.coffee || options.coffeeScript) {
     debug('enabled CoffeeScript');
     exts.push('coffee')
   }
-  
-  
+
+
   this._routes.init(app);
-  
+
   // Forward function calls from Locomotive to Express.  This allows Locomotive
   // to be used interchangably with Express.
   utils.forward(this, app, [ 'configure', 'get', 'set', 'enabled', 'disabled', 'enable', 'disable',
-                             'use', 'engine', 'locals' ]);
+                             'use', 'engine' ]);
   this.express = app;
   this.router = app.router;
   this.mime = express.mime;
-  
+
   this.helpers(require('./helpers'));
   this.dynamicHelpers(require('./helpers/dynamic'));
-  
+
   // Set the environment.  This syncs Express with the environment supplied to
   // the Locomotive CLI.
   this.env = env;
   this.set('env', env);
-  
-  
+
+  // Setup Locals
+  this.locals = app.locals;
+
   this.phase(require('bootable-environment')({ dirname: options.environmentsDir, env: env }, this));
   this.phase(bootable.initializers({ dirname: options.initializersDir }, this));
   this.phase(require('./boot/fallbacks')(this));
   this.phase(require('./boot/controllers')({ dirname: options.controllersDir }, this));
   this.phase(bootable.routes({ filename: options.routesFile }, this._routes));
-  
+
   this._initializer.run(function(err) {
     if (err) { return callback(err); }
     callback(null, app);


### PR DESCRIPTION
At some point Express changed the way it scoped Express.app.locals, so using the Locomotive.utils.forward method was rendering it broken.
