### PR TITLE
Added option to support Streamline '._js' files

### DIFF
--- a/lib/locomotive/index.js
+++ b/lib/locomotive/index.js
@@ -272,6 +272,11 @@ Locomotive.prototype.boot = function(dir, env, options, callback) {
     debug('enabled CoffeeScript');
     exts.push('coffee')
   }
+
+  if (options.streamline) {
+    debug('enabled Streamline');
+    exts.push('_js')
+  }
   
   
   this._routes.init(app);


### PR DESCRIPTION
Similarly to CoffeeScript support, this patch adds an option to support [streamline](https://github.com/Sage/streamlinejs) `._js` files.

It assumes (as with CoffeeScript) that the user boots Locomotive manually (similar to [this](http://stackoverflow.com/a/14511114/893780)) after having configured the streamline loader (see [this](https://github.com/Sage/streamlinejs/blob/master/examples/loader/loader.md)).
