### PR TITLE
Pass locals into custom response functions

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -51,6 +51,38 @@ Controller.prototype.params = function(name, defaultValue) {
 };
 
 /**
+ * Return the controller's local properties to be made available to the view.
+ * @api private
+ */
+Controller.prototype.localProperties = function() {
+  var self = this;
+  var filtered = {};
+
+  // Filter function to capture the controller's local properties, which will
+  // be made available to the view.  Any private property (defined as a property
+  // whose name begins with an underscore), or property existing prior to
+  // invoking the action will be filtered out.
+  function isLocalProperty(prop) {
+    if (prop[0] === '_') { return false };
+    if (self.__ownProperties.indexOf(prop) != -1) { return false };
+    return true;
+  }
+  
+  Object.keys(this).filter(isLocalProperty).forEach(function(key) {
+    var value = self[key];
+
+    // TODO: Implement a test case for this.
+    // Make sure functions are always run in the current controllers` context.
+    if (value instanceof Function)
+      value = value.bind(self);
+
+    filtered[key] = value;
+  });
+
+  return filtered;
+}
+
+/**
  * Render response.
  *
  * Render `template`, defaulting to the template for the current action, with
@@ -103,28 +135,8 @@ Controller.prototype.render = function(template, options, fn) {
   
   tmpl = (tmpl.indexOf('/') === -1) ? this.__id + '/' + tmpl : tmpl;
   tmpl = this.__app.views.resolve(tmpl);
-  
-  // Filter function to capture the controller's local properties, which will
-  // be made available to the view.  Any private property (defined as a property
-  // whose name begins with an underscore), or property existing prior to
-  // invoking the action will be filtered out.
-  function localProperties(prop) {
-    if (prop[0] == '_') { return false; }
-    if (self.__ownProperties.indexOf(prop) != -1) { return false; }
-    return true;
-  }
-  
-  Object.keys(this).filter(localProperties).forEach(function(key) {
-    var value = self[key];
 
-    // Make sure functions are always run in the current controllers` context.
-    // TODO: Implement test case for this.
-    if (value instanceof Function) {
-      value = value.bind(self);
-    }
-
-    self.__res.locals[key] = value;
-  });
+  this.__res.locals = this.localProperties()
   
   var fopts = this.__app._formats[fmt] || {}
     , comps = [ tmpl, fmt, (app && app.set('view engine')) || 'ejs' ]
@@ -177,9 +189,10 @@ Controller.prototype.render = function(template, options, fn) {
  * options found in the object.
  *
  *     this.respond({
- *       'json': { template: 'jrd', engine: 'jsonb' },
- *       'xml': { template: 'xrd', engine: 'xmlb' }
- *     });
+ *       'xml': function() { self.render('atom', { engine: 'xmlb' }); },
+ *       'json': function(data) { self.res.json(data); },
+ *       default: function() { self.render(); }
+ *     })
  *
  * If the template and options are defaults, which don't need to be overridden,
  * simply set the format key to `true`.
@@ -255,7 +268,7 @@ Controller.prototype.respondWith = function(obj) {
     if (key && key.indexOf('/') != -1) { op.mime = key; }
     this.render(template, op);
   } else if (typeof op == 'function') {
-    op();
+    op(this.localProperties());
   } else {
     var err = new Error('Not Acceptable');
     err.status = 406;


### PR DESCRIPTION
Previously, it was a pain to respond to a request with JSON while using `respond`. The controller object is cyclical, so passing it into `JSON.stringify` fails. Furthermore, that doesn't filter underscores.  

So, this simply passes properly-filtered locals into custom response functions. It could be used for all sorts of things that accept plain ol' JSON, but here's a simple example of responding with either HTML or JSON:

```
pagesController.main = function() {
  var self = this;
  this.title = 'Locomotive';
  this.respond({
    html: true,
    json: function(locals) { self.res.json(locals); } // new magic
  })
};
```

I've only tested manually, but I'd be happy to write up some tests!
