### PR TITLE
Allow before and after filters to be created by chaining together declarations

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -417,6 +417,8 @@ Controller.prototype.before = function(action, fn) {
   } else {
     this.__beforeFilters.push({ action: action, fn: fn });
   }
+
+  return this;
 };
 
 /**
@@ -447,6 +449,8 @@ Controller.prototype.after = function(action, fn) {
   } else {
     this.__afterFilters.push({ action: action, fn: fn });
   }
+
+  return this;
 };
 
 /**

--- a/test/controller.filters.after.test.js
+++ b/test/controller.filters.after.test.js
@@ -1274,5 +1274,72 @@ describe('Controller#after', function() {
       expect(controller.order[2]).to.equal(2);
     });
   });
-  
+
+  describe('filter declaration using chaining syntax', function() {
+    var app = new MockApplication();
+    var controller = new Controller();
+    controller.order = [];
+
+    controller.show = function() {
+      this.order.push('a');
+      this.song = 'Mr. Jones';
+      this._private = 'Untitled';
+      this.render();
+    };
+
+    // Chain together filters
+    controller
+      .after('show', function(next) {
+        this.order.push(1);
+        this.band = 'Counting Crows';
+        next();
+      })
+      .after('show', function(next) {
+        this.order.push(2);
+        this.album = 'August and Everything After';
+        next();
+      })
+      .after('index', function(next) {
+        this.order.push('x');
+        this.store = 'Amoeba Music';
+        next();
+      });
+
+    var req, res;
+
+    before(function(done) {
+      req = new MockRequest();
+      res = new MockResponse();
+
+      controller.after('show', function(next) {
+        return done();
+      });
+
+      controller._init(app, 'test');
+      controller._prepare(req, res, function(err) {
+        if (err) { return done(err); }
+        return done(new Error('should not call next'));
+      });
+      controller._invoke('show');
+    });
+
+    it('should apply filters in correct order', function() {
+      expect(controller.order).to.have.length(3);
+      expect(controller.order[0]).to.equal('a');
+      expect(controller.order[1]).to.equal(1);
+      expect(controller.order[2]).to.equal(2);
+    });
+
+    it('should render view without options', function() {
+      expect(res._view).to.equal('test/show.html.ejs');
+      expect(res._options).to.be.an('object');
+      expect(Object.keys(res._options)).to.have.length(0);
+    });
+
+    it('should assign locals', function() {
+      expect(res.locals).to.be.an('object');
+      expect(Object.keys(res.locals)).to.have.length(1);
+      expect(res.locals.song).to.equal('Mr. Jones');
+    });
+  });
 });


### PR DESCRIPTION
Controller before and after filters must be declared in the following way

``` javascript
controller.before('action1', filterA);
controller.before('action1', filterB);
controller.before('action1', filterC);

controller.before('action2', filterA);
controller.before('action2', filterB);
```

In cases where a controller has many actions and many filters, it would be nice if we could declare filters by chaining the declarations together

``` javascript
controller
 .before('action1', filterA)
 .before('action1', filterB)
 .before('action1', filterC);

controller
 .before('action2', filterA)
 .before('action2', filterB);
```

This makes the code a little easier to read, and encourages developers to arrange filters into distinct ordered blocks, rather than as code that could be inserted anywhere in the controller.

To support this, I've made two small changes to controller.js, and added a single test to each of the filter test suites, which should be sufficient to test the syntax.
