### PR TITLE
Add support for promises.

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -567,7 +567,12 @@ Controller.prototype._invoke = function(action) {
     if (!filter) {
       // filters done, invoke action
       try {
-        self[action](data);
+        var promise = self[action](data);
+        if (promise && typeof promise.then === 'function') {
+          promise.then(null, function (err) {
+            self.error(err);
+          });
+        }
         return;
       } catch (ex) {
         return self.error(ex);


### PR DESCRIPTION
This commit adds a very basic support for promises. The change allows developers to let rejected promises propagate in the same way an exception would. This is very useful if you're using a promise library (e.g. [q](https://github.com/kriskowal/q)).
