### PR TITLE
Simplified console output

### DIFF
--- a/lib/cli/create.js
+++ b/lib/cli/create.js
@@ -93,13 +93,11 @@ var routesTemplate = [
 ].join(eol);
 
 var allEnvironments = [
-    'var util = require(\'util\');'
-  , ''
-  , 'module.exports = function() {'
+    'module.exports = function() {'
   , '  // Warn of version mismatch between global "lcm" binary and local installation'
   , '  // of Locomotive.'
   , '  if (this.version !== require(\'locomotive\').version) {'
-  , '    console.warn(util.format(\'version mismatch between local (%s) and global (%s) Locomotive module\', require(\'locomotive\').version, this.version));'
+  , '    console.warn(\'version mismatch between local (%s) and global (%s) Locomotive module\', require(\'locomotive\').version, this.version);'
   , '  }'
   , '}'
   , ''


### PR DESCRIPTION
Removed util.format since console can format strings (using util.format) automatically.
