### PR TITLE
Allow configuring http server options using app settings

### DIFF
--- a/lib/boot/httpserver.js
+++ b/lib/boot/httpserver.js
@@ -34,10 +34,11 @@ module.exports = function(port, address, options) {
     port = undefined;
   }
   options = options || {};
-  port = port || options.port || 3000;
-  address = address || options.address || '0.0.0.0';
   
   return function httpServer(done) {
+    port = port || options.port || this.get('port') || 3000;
+    address = address || options.address || this.get('address') || '0.0.0.0';
+    
     http.createServer(this.express).listen(port, address, function() {
       var addr = this.address();
       console.info('HTTP server listening on %s:%d', addr.address, addr.port);

--- a/lib/boot/httpservercluster.js
+++ b/lib/boot/httpservercluster.js
@@ -37,12 +37,13 @@ module.exports = function(port, address, options) {
     port = undefined;
   }
   options = options || {};
-  port = port || options.port || 3000;
-  address = address || options.address || '0.0.0.0';
   
   var size = options.size || os.cpus().length;
   
   return function httpServerCluster(done) {
+    port = port || options.port || this.get('port') || 3000;
+    address = address || options.address || this.get('address') || '0.0.0.0';
+    
     if (cluster.isMaster) {
       console.info('Creating HTTP server cluster with %d workers', size);
       


### PR DESCRIPTION
Allow configuring http server options using app settings using `this.set('port', 3000)` and `this.set('address', '0.0.0.0')`.
