### PR TITLE
Use 'app.get()' instead of 'app.set()'

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -127,7 +127,7 @@ Controller.prototype.render = function(template, options, fn) {
   });
   
   var fopts = this.__app._formats[fmt] || {}
-    , comps = [ tmpl, fmt, (app && app.set('view engine')) || 'ejs' ]
+    , comps = [ tmpl, fmt, (app && app.get('view engine')) || 'ejs' ]
     , ext;
   if (options.engine) {
     comps = [ tmpl, fmt, options.engine ];


### PR DESCRIPTION
Replaced `app.set('view engine')` with `app.get('view engine')`, because value isn't being set, only retrieved.